### PR TITLE
Prevent Maven target from grabbing transitive dependencies

### DIFF
--- a/build/core/maven_artifact.mk
+++ b/build/core/maven_artifact.mk
@@ -41,7 +41,8 @@ $(LOCAL_PREBUILT_MODULE_FILE):
 		-DoutputDirectory=$(dir $@) \
 		-Dmdep.prependGroupId=true \
 		-Dmdep.overWriteSnapshots=true \
-		-Dmdep.overWriteReleases=true
+		-Dmdep.overWriteReleases=true \
+		-Dtransitive=false
 	@echo -e ${CL_GRN}"Download:"${CL_RST}" $@"
 
 include $(BUILD_PREBUILT)


### PR DESCRIPTION
Dependencies of Maven targets will have to be managed manually. The prebuilt
target that the Maven target is based off of wasn't designed to handle multiple
artifacts per project. Additionally, this target is mainly intended for grabbing
APKs or other standalone blobs, not for pulling in a full jar dependency tree.
If that is your use case, you may want to investigate simply converting your
project to Gradle (or the Maven build system, if you can stomach it).

Change-Id: Iaf48c95c704cfdc85e0074394ff3c7464937e60c